### PR TITLE
Misc maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,20 +6,18 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      # reference:
-      # https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macosexecutor
       - image: circleci/clojure:tools-deps
         command: "/bin/bash"
 
     environment:
-      DEP_FALLBACK: '{:deps {cljdoc-analyzer {:git/url "https://github.com/cljdoc/cljdoc-analyzer.git" :sha "323343a3d644fed486621032bd0b5a21171e4b09"}}})'
+      DEP_FALLBACK: '{:deps {cljdoc-analyzer {:git/url "https://github.com/cljdoc/cljdoc-analyzer.git" :sha "50d5e657172d99ec5fb046142747347036fb9859" }}})'
 
     steps:
       # Env vars cannot be used for cache keys so we put
       # it in a file and use the checksum of that file
-      # https://discuss.circleci.com/t/10994/9
-      - run: echo ${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK} > /tmp/cache-key
+      - run:
+          name: Setup for cache
+          command: echo ${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK} > /tmp/cache-key
 
       - restore_cache:
           keys:
@@ -27,16 +25,25 @@ jobs:
           - v1-dependencies- # fallback if not cache found
 
       - run:
+          name: Dump tools versions
+          command: |
+            echo java -version
+            java -version
+            echo clojure -Sdescribe
+            clojure -Sdescribe
+
+      - run:
           name: Print build parameters
           command: echo "$CLJDOC_ANALYZER_ARGS"
 
       - run:
           name: Run analysis
-          command: clojure -Sdeps "${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK}" -m cljdoc-analyzer.cljdoc-main "${CLJDOC_ANALYZER_ARGS:-$FALLBACK}"
+          command: clojure -Sdeps "${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK}" -M -m cljdoc-analyzer.cljdoc-main "${CLJDOC_ANALYZER_ARGS:-$FALLBACK}"
           environment:
             - FALLBACK: '{:project "bidi" :version "2.1.3" :jarpath "https://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.jar" :pompath "https://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.pom"}'
 
       - store_artifacts:
+          # WARNING: this path must match cljdoc-shared.analysis/output-prefix
           path: /tmp/cljdoc/analysis-out/
           destination: /
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Analyzer Service for [cljdoc](https://github.com/martinklepsch/cljdoc)
+# Builder - API Analysis Job Runner for cljdoc
 
-#### Basic Idea
+Cljdoc's API analysis supports the discovery of load-time generated APIs.
+This makes API analysis potentially unsafe.
 
-- Trigger parameterized builds that run [analyze.sh](https://github.com/martinklepsch/cljdoc/blob/master/script/analyze.sh)
-- Store resulting edn as build artifact
-- Tell non-sandboxed system that new stuff is available via webhook
+For this reason, and to pipeline API analysis, cljdoc offloads this task to the builder, a CircleCI job in this project.
 
-#### Running builds via Circle CI API
-
-See [`script/trigger-circle-analysis.sh`](https://github.com/martinklepsch/cljdoc/blob/master/script/trigger-circle-analysis.sh) in the main [cljdoc repo](https://github.com/martinklepsch/cljdoc/).
+1. The cljdoc web server triggers this project's CircleCI job to run cljdoc-analyzer on a specific library and waits for the job to complete
+2. The job saves the cljdoc-analyzer result, an edn file describing library's API, to a known location
+3. After the job is complete the cljdoc web server picks up the result and stores it as a build artifact


### PR DESCRIPTION
- Update stale README
- Bump referenced cljdoc-analyzer fallback sha to current
- Turf dead links, stale comments
- Use current clojure CLI syntax, closes #2
- Add a comment about artifact path, relates to cljdoc/cljdoc#540
- Dump java and clojure versions that job is using