### PR TITLE
bump clojure image to clojure:temurin-19-tools-deps & add --enable-preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: clojure:temurin-17-tools-deps
+      - image: clojure:temurin-19-tools-deps
 
     # The fallback setup is only for sanity testing, when changes are made to the builder project itself it will use fallback values.
     # When builder is triggered by cljdoc it will always pass in teh appropriate arguments.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run:
           name: Run analysis
-          command: clojure -Sdeps "${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK}" -M -m cljdoc-analyzer.cljdoc-main "${CLJDOC_ANALYZER_ARGS:-$FALLBACK}"
+          command: clojure -Sdeps '${CLJDOC_ANALYZER_DEP:-$DEP_FALLBACK :jvm-opts ["--enable-preview"]}' -M -m cljdoc-analyzer.cljdoc-main "${CLJDOC_ANALYZER_ARGS:-$FALLBACK}"
           environment:
             - FALLBACK: '{:project "bidi" :version "2.1.3" :jarpath "https://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.jar" :pompath "https://repo.clojars.org/bidi/bidi/2.1.3/bidi-2.1.3.pom"}'
 


### PR DESCRIPTION
that would allow to build projects relying on java19 with preview features such as loom