### PR TITLE
Upgrade from JDK 17 to JDK 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: clojure:temurin-17-tools-deps
+      - image: clojure:temurin-21-tools-deps-jammy
 
     # The fallback setup is only for sanity testing, when changes are made to the builder project itself it will use fallback values.
     # When builder is triggered by cljdoc it will always pass in teh appropriate arguments.


### PR DESCRIPTION
Default linux distro for clojure docker images changed from ubuntu to debian. We'll stick with ubuntu for now.