### PR TITLE
Upgrade builder from jdk21 to jdk23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: clojure:temurin-21-tools-deps-jammy
+      - image: clojure:temurin-23-tools-deps-noble
 
     # The fallback setup is only for sanity testing, when changes are made to the builder project itself it will use fallback values.
     # When builder is triggered by cljdoc it will always pass in teh appropriate arguments.


### PR DESCRIPTION
Some libs require a later JDK to pass dynamic API analysis